### PR TITLE
Change quilt-to-intermediary saved file name to prevent Windows-based errors

### DIFF
--- a/src/main/java/com/oroarmor/quiltmappings/loom/QuiltMappingsOnLoomPlugin.java
+++ b/src/main/java/com/oroarmor/quiltmappings/loom/QuiltMappingsOnLoomPlugin.java
@@ -74,7 +74,7 @@ public class QuiltMappingsOnLoomPlugin implements Plugin<Project> {
         public void visit(MappingVisitor mappingVisitor) throws IOException {
             String minecraftVersion = context.minecraftProvider().minecraftVersion();
 
-            File intermediaryToQm = project.file(".gradle/qm/qm_to_intermediary_" + quiltMappings + ".tiny");
+            File intermediaryToQm = project.file(".gradle/qm/qm_to_intermediary_" + quiltMappings.split(':')[2] + ".tiny");
 
             if (!intermediaryToQm.exists()) {
                 Set<File> quiltmappings = project.getConfigurations().detachedConfiguration(project.getDependencies().create(quiltMappings)).resolve();


### PR DESCRIPTION
If using Windows, the attempted previous name would fail because of the `:` character.
My change grabs only the version rather than the entire artifact name to hopefully prevent crashes