### PR TITLE
Set Java compatibility level to 16

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,11 @@ gradlePlugin {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_16
+    targetCompatibility = JavaVersion.VERSION_16
+}
+
 publishing {
     repositories {
         mavenLocal()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.quiltmc"
-version = "3.1.0"
+version = "3.1.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Loom is still on Java 16 and no Java 17 features are used. This is slightly more convenient for people who want to use this on 1.17.1 without updating their jdk