### PR TITLE
Fix loss of initializer parameters, add unpick support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ Replace `QMoL_VERSION` in `build.gradle` with the version corresponding to the v
 | Loom Version | QMoL Version |
 | - | - |
 | 0.10 | 3.1.2 |
-| 0.11 | 4.0.0 |
+| 0.11.31- | 4.0.0 |
+| 0.11.32+ | 4.1.0 |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.quiltmc"
-version = "4.0.0"
+version = "4.0.1"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "org.quiltmc"
-version = "4.0.1"
+version = "4.1.0"
 
 repositories {
     mavenCentral()

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
-    id("fabric-loom") version "0.10-SNAPSHOT"
-    id("quilt-mappings-on-loom") version "3.0.0"
+    id("fabric-loom") version "0.11.32"
+    id("org.quiltmc.quilt-mappings-on-loom") version "4.0.1"
 }
 
 group = "org.quiltmc"
@@ -14,8 +14,8 @@ repositories {
     }
 }
 
-var minecraft_version = "1.18-pre3"
-var quilt_mappings = "1.18-pre3+build.2"
+var minecraft_version = "1.18.2-rc1"
+var quilt_mappings = "1.18.2-rc1+build.1"
 var loader_version = "0.12.2"
 
 dependencies {

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     id("fabric-loom") version "0.11.32"
-    id("org.quiltmc.quilt-mappings-on-loom") version "4.0.1"
+`    id("org.quiltmc.quilt-mappings-on-loom") version "4.1.0"
 }
 
 group = "org.quiltmc"

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     id("fabric-loom") version "0.11.32"
-`    id("org.quiltmc.quilt-mappings-on-loom") version "4.1.0"
+    id("org.quiltmc.quilt-mappings-on-loom")
 }
 
 group = "org.quiltmc"

--- a/test/gradle.properties
+++ b/test/gradle.properties
@@ -1,0 +1,2 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx1G

--- a/test/settings.gradle.kts
+++ b/test/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
 		}
 		maven { url = uri("https://maven.quiltmc.org/repository/release") }
 	}
+	includeBuild("..")
 }
 
 rootProject.name = "quilt-mappings-on-loom-test"


### PR DESCRIPTION
Fixes final mapping file not containing any initializer parameters.

Should we change the hash code of the mappings so that when the plugin is updated, the old mappings aren't used? As it is now, updating to 4.0.1 without deleting the cached mappings file, or changing the mappings dependency to an uncached one, doesn't have any effect