### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ dependencies {
    })
 }
 ```
+`gradle.properties`:
+```properties
+minecraft_version=1.18.2
+quilt_mappings=22
+
+# ...
+```
 ### QMoL Versions
 Replace `QMoL_VERSION` in `build.gradle` with the version corresponding to the version of Loom being used:
 | Loom Version | QMoL Version |
@@ -48,3 +55,4 @@ Replace `QMoL_VERSION` in `build.gradle` with the version corresponding to the v
 | 0.10 | 3.1.2 |
 | 0.11.31- | 4.0.0 |
 | 0.11.32+ | 4.1.0 |
+|          | 4.2.0 |


### PR DESCRIPTION
Adds new/current QMoL_VERSION to the table, however I'm not sure which loom version this corresponds to.

I also figured it'd be a good idea to mention the necessary changes for `gradle.properties` - specifically since `quilt_mappings` is expected to be there (unless I'm misunderstanding something)