### PR TITLE
Update QMoL Version for loom 0.11.32+

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Replace `QMoL_VERSION` in `build.gradle` with the version corresponding to the v
 | - | - |
 | 0.10 | 3.1.2 |
 | 0.11.31- | 4.0.0 |
-| 0.11.32+ | 4.1.0 |
+| 0.11.32+ | 4.2.0 |


### PR DESCRIPTION
Fixies #10 

No maven `4.1.0` version. Upgrading to `4.2.0`