### PR TITLE
Avoid loom removing <init> parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Replace `QMoL_VERSION` in `build.gradle` with the version corresponding to the v
 | - | - |
 | 0.10 | 3.1.2 |
 | 0.11.31- | 4.0.0 |
-| 0.11.32+ | 4.2.0 |
+| 0.11.32+ | 4.2.1 |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 group = "org.quiltmc"
 // Don't forget to update README.MD
-version = "4.2.0"
+version = "4.2.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/org/quiltmc/quiltmappings/loom/QuiltMappingsOnLoomPlugin.java
+++ b/src/main/java/org/quiltmc/quiltmappings/loom/QuiltMappingsOnLoomPlugin.java
@@ -138,7 +138,7 @@ public class QuiltMappingsOnLoomPlugin implements Plugin<Project> {
                 MemoryMappingTree tree = new MemoryMappingTree();
                 mappingTree.accept(tree);
                 Tiny2Reader.read(new FileReader(intermediaryToQm), tree);
-                tree.accept(new MappingNsCompleter(mappingVisitor, Map.of(MappingsNamespace.INTERMEDIARY.toString(), MappingsNamespace.OFFICIAL.toString()), true));
+                tree.accept(new MappingNsCompleter(mappingVisitor, Map.of(MappingsNamespace.INTERMEDIARY.toString(), MappingsNamespace.OFFICIAL.toString())));
             } else {
                 // Shouldn't happen, unless the impl changes to not use a MappingTree
                 Tiny2Reader.read(new FileReader(intermediaryToQm), mappingVisitor);

--- a/src/main/java/org/quiltmc/quiltmappings/loom/QuiltMappingsOnLoomPlugin.java
+++ b/src/main/java/org/quiltmc/quiltmappings/loom/QuiltMappingsOnLoomPlugin.java
@@ -21,12 +21,13 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
-import net.fabricmc.loom.util.Constants;
+import net.fabricmc.mappingio.adapter.MappingNsCompleter;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
+import net.fabricmc.mappingio.tree.MappingTree;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.util.GFileUtils;
@@ -43,7 +44,7 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 @SuppressWarnings("UnstableApiUsage")
 public class QuiltMappingsOnLoomPlugin implements Plugin<Project> {
-    private static final int HASH_CODE_VERSION_BASE = 1;
+    private static final int HASH_CODE_VERSION_BASE = 2;
     private static final int HASH_CODE_VERSION_EXTRA_BITS = 8;
     private static final int HASH_CODE_VERSION = (1 << HASH_CODE_VERSION_EXTRA_BITS) + HASH_CODE_VERSION_BASE;
 
@@ -132,7 +133,16 @@ public class QuiltMappingsOnLoomPlugin implements Plugin<Project> {
                 }
             }
 
-            Tiny2Reader.read(new FileReader(intermediaryToQm), mappingVisitor);
+            if (mappingVisitor instanceof MappingTree mappingTree) {
+                // Complete missing intermediary names with official ones (i.e. <init>s) to avoid losing mappings
+                MemoryMappingTree tree = new MemoryMappingTree();
+                mappingTree.accept(tree);
+                Tiny2Reader.read(new FileReader(intermediaryToQm), tree);
+                tree.accept(new MappingNsCompleter(mappingVisitor, Map.of(MappingsNamespace.INTERMEDIARY.toString(), MappingsNamespace.OFFICIAL.toString()), true));
+            } else {
+                // Shouldn't happen, unless the impl changes to not use a MappingTree
+                Tiny2Reader.read(new FileReader(intermediaryToQm), mappingVisitor);
+            }
         }
 
         private void extractMappings(File dependency, File output) {


### PR DESCRIPTION
Because loom switches the result mappings source namespace to intermediary, <init> parameters are lost because intermediary doesn't contain the method. This change just completes intermediary with those names to keep them